### PR TITLE
Move the tests to constraints

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -27,7 +27,9 @@ $header = trim(
     ),
 ));
 
-$config = new FidryConfig($header, 80_000);
-$config->addRules(['no_trailing_whitespace_in_string' => false]);
+$config = new FidryConfig($header, 74_000);
+$config->addRules([
+    'no_trailing_whitespace_in_string' => false,
+]);
 
 return $config->setFinder($finder);

--- a/infection.json.dist
+++ b/infection.json.dist
@@ -13,48 +13,10 @@
     "mutators": {
         "@default": true,
         "MBString": false,
-        "global-ignoreSourceCodeByRegex": [
-            "Assert::.*",
-            "ConsoleAssert::.*",
-            "break;"
-        ],
-        "CastString": {
+
+        "GreaterThan": {
             "ignore": [
-                "Fidry\\Console\\IO::getStringArgument"
-            ]
-        },
-        "CastInt": {
-            "ignore": [
-                "Fidry\\Console\\InputAssert::castThrowException"
-            ]
-        },
-        "LessThan": {
-            "ignoreSourceCodeByRegex": [
-                ".*\\$min < \\$max.*"
-            ]
-        },
-        "LogicalOr": {
-            "ignore": [
-                "Fidry\\Console\\Internal\\Generator\\GetterGenerator::isPsalmTypeRedundant"
-            ]
-        },
-        "MethodCallRemoval": {
-            "ignore": [
-                "Fidry\\Console\\Command\\SymfonyCommand::setApplication",
-                "Fidry\\Console\\Input\\IO::__construct",
-                "Fidry\\Console\\Internal\\Type\\NaturalType::coerceValue",
-                "Fidry\\Console\\Internal\\Type\\PositiveIntegerType::coerceValue"
-            ]
-        },
-        "PublicVisibility": false,
-        "UnwrapStrReplace": {
-            "ignore": [
-                "Fidry\\Console\\DisplayNormalizer::removeTrailingSpaces"
-            ]
-        },
-        "UnwrapArrayValues": {
-            "ignore": [
-                "Fidry\\Console\\Application\\SymfonyApplication::getSymfonyCommands"
+                "Fidry\\Makefile\\Test\\Constraint\\SinglePrerequisitePhony::checkHasOnePrerequisite"
             ]
         }
     }

--- a/psalm.xml
+++ b/psalm.xml
@@ -32,11 +32,21 @@
                 <referencedFunction name="Safe\sprintf"/>
             </errorLevel>
         </DeprecatedFunction>
-        
+
         <ForbiddenCode>
             <errorLevel type="suppress">
                 <file name="src/Test/BaseMakefileTestCase.php"/>
             </errorLevel>
         </ForbiddenCode>
+
+        <InternalMethod errorLevel="suppress"/>
+
+        <MissingConstructor>
+            <errorLevel type="suppress">
+                <file name="src/Test/Constraint/BaseConstraint.php"/>
+            </errorLevel>
+        </MissingConstructor>
+
+        <UnusedConstructor errorLevel="suppress"/>
     </issueHandlers>
 </psalm>

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -133,9 +133,9 @@ final class Parser
             array_filter(
                 array_map(
                     static fn (string $dependency) => $multiline ? ltrim($dependency, '\\') : $dependency,
-                    explode(' ', $dependencies)
-                )
-            )
+                    explode(' ', $dependencies),
+                ),
+            ),
         );
     }
 }

--- a/src/Rule.php
+++ b/src/Rule.php
@@ -36,6 +36,11 @@ declare(strict_types=1);
 
 namespace Fidry\Makefile;
 
+use function current;
+use function implode;
+use function sprintf;
+use function str_starts_with;
+
 final class Rule
 {
     private const PHONY_TARGET = '.PHONY';
@@ -46,6 +51,14 @@ final class Rule
      * @var list<string>
      */
     private array $prerequisites;
+
+    /**
+     * @param list<string> $prerequisites
+     */
+    public static function createPhony(array $prerequisites): self
+    {
+        return new self(self::PHONY_TARGET, $prerequisites);
+    }
 
     /**
      * @param list<string> $prerequisites
@@ -80,11 +93,42 @@ final class Rule
         );
     }
 
+    public function isComment(): bool
+    {
+        $firstPrerequisite = current($this->prerequisites);
+
+        if (false === $firstPrerequisite) {
+            return false;
+        }
+
+        return str_starts_with($firstPrerequisite, '#');
+    }
+
+    public function isCommandComment(): bool
+    {
+        $firstPrerequisite = current($this->prerequisites);
+
+        if (false === $firstPrerequisite) {
+            return false;
+        }
+
+        return str_starts_with($firstPrerequisite, '##');
+    }
+
     /**
      * @return list<string>
      */
     public function getPrerequisites(): array
     {
         return $this->prerequisites;
+    }
+
+    public function toString(): string
+    {
+        return sprintf(
+            '%s: %s',
+            $this->target,
+            implode(' ', $this->prerequisites),
+        );
     }
 }

--- a/src/Test/Assert.php
+++ b/src/Test/Assert.php
@@ -1,0 +1,89 @@
+<?php
+
+/*
+ * This code is licensed under the BSD 3-Clause License.e
+ *
+ * Copyright (c) 2022, Théo FIDRY <theo.fidry@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Fidry\Makefile\Test;
+
+use Fidry\Makefile\Rule;
+use Fidry\Makefile\Test\Constraint\NoDuplicateTarget;
+use Fidry\Makefile\Test\Constraint\SinglePrerequisitePhony;
+use Fidry\Makefile\Test\Constraint\ValidCommandDeclaration;
+use PHPUnit\Framework\Assert as PHPUnitAssert;
+use PHPUnit\Framework\ExpectationFailedException;
+
+final class Assert extends PHPUnitAssert
+{
+    /**
+     * Asserts that the rule is a .PHONY rule with one and only one pre-requisite.
+     *
+     * @throws ExpectationFailedException
+     */
+    public static function assertSinglePrerequisitePhony(Rule $rule, string $message = ''): void
+    {
+        $constraint = new SinglePrerequisitePhony();
+
+        self::assertThat($rule, $constraint, $message);
+    }
+
+    /**
+     * Asserts that the rules have valid PHONY target declarations, i.e. it
+     * declares a single target, is optionally followed by a comment line and
+     * then a rule to declare the command itself.
+     *
+     * @param list<Rule> $rules
+     */
+    public static function assertHasValidPhonyTargetDeclarations(
+        array $rules,
+        string $message = ''
+    ): void {
+        $constraint = new ValidCommandDeclaration();
+
+        self::assertThat($rules, $constraint, $message);
+    }
+
+    /**
+     * Asserts that the a rule target is not declared twice.
+     *
+     * @param list<Rule> $rules
+     */
+    public static function assertNoDuplicateTarget(
+        array $rules,
+        string $message = ''
+    ): void {
+        $constraint = new NoDuplicateTarget();
+
+        self::assertThat($rules, $constraint, $message);
+    }
+}

--- a/src/Test/Constraint/BaseConstraint.php
+++ b/src/Test/Constraint/BaseConstraint.php
@@ -1,0 +1,83 @@
+<?php
+
+/*
+ * This code is licensed under the BSD 3-Clause License.e
+ *
+ * Copyright (c) 2022, Théo FIDRY <theo.fidry@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Fidry\Makefile\Test\Constraint;
+
+use PHPUnit\Framework\Constraint\Constraint;
+
+/**
+ * @internal
+ */
+abstract class BaseConstraint extends Constraint
+{
+    protected string $failureDescription;
+
+    final public function evaluate($other, string $description = '', bool $returnResult = false): ?bool
+    {
+        unset($this->failureDescription);
+        $success = false;
+
+        try {
+            $this->checkOther($other, $description);
+
+            $success = true;
+        } catch (MatchingFailure $matchingFailure) {
+            $this->failureDescription = $matchingFailure->getMessage();
+        }
+
+        if ($returnResult) {
+            return $success;
+        }
+
+        if (!$success) {
+            $this->fail($other, $description);
+        }
+
+        return null;
+    }
+
+    final protected function failureDescription($other): string
+    {
+        return $this->failureDescription ?? parent::failureDescription($other);
+    }
+
+    /**
+     * @param mixed $other
+     *
+     * @throws MatchingFailure
+     */
+    abstract public function checkOther($other, string $description): void;
+}

--- a/src/Test/Constraint/BaseConstraint.php
+++ b/src/Test/Constraint/BaseConstraint.php
@@ -45,6 +45,9 @@ abstract class BaseConstraint extends Constraint
 {
     protected string $failureDescription;
 
+    /**
+     * @param mixed $other
+     */
     final public function evaluate($other, string $description = '', bool $returnResult = false): ?bool
     {
         unset($this->failureDescription);
@@ -71,6 +74,7 @@ abstract class BaseConstraint extends Constraint
 
     final protected function failureDescription($other): string
     {
+        /** @psalm-suppress RedundantPropertyInitializationCheck */
         return $this->failureDescription ?? parent::failureDescription($other);
     }
 

--- a/src/Test/Constraint/MatchingFailure.php
+++ b/src/Test/Constraint/MatchingFailure.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This code is licensed under the BSD 3-Clause License.e
+ *
+ * Copyright (c) 2022, Théo FIDRY <theo.fidry@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Fidry\Makefile\Test\Constraint;
+
+use RuntimeException;
+
+/**
+ * @internal
+ */
+final class MatchingFailure extends RuntimeException
+{
+}

--- a/src/Test/Constraint/NoDuplicateTarget.php
+++ b/src/Test/Constraint/NoDuplicateTarget.php
@@ -1,0 +1,135 @@
+<?php
+
+/*
+ * This code is licensed under the BSD 3-Clause License.e
+ *
+ * Copyright (c) 2022, Théo FIDRY <theo.fidry@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Fidry\Makefile\Test\Constraint;
+
+use Fidry\Makefile\Rule;
+use function array_key_exists;
+use function get_debug_type;
+use function is_array;
+use function Safe\sprintf;
+
+final class NoDuplicateTarget extends BaseConstraint
+{
+    public function toString(): string
+    {
+        return 'is not declared twice';
+    }
+
+    public function checkOther($other, string $description): void
+    {
+        self::checkIsArrayOfRules($other);
+        self::checkDuplicates($other);
+    }
+
+    /**
+     * @param mixed $other
+     * @psalm-assert Rule[] $other
+     *
+     * @throws MatchingFailure
+     */
+    private static function checkIsArrayOfRules($other): void
+    {
+        if (!is_array($other)) {
+            throw new MatchingFailure(
+                sprintf(
+                    'the value to be an array of "%s" instances. Got "%s"',
+                    Rule::class,
+                    get_debug_type($other),
+                ),
+            );
+        }
+
+        foreach ($other as $index => $value) {
+            if (!($value instanceof Rule)) {
+                throw new MatchingFailure(
+                    sprintf(
+                        'the value to be an array of "%s" instances. Got "%s" for the item of index "%s"',
+                        Rule::class,
+                        get_debug_type($value),
+                        $index,
+                    ),
+                );
+            }
+        }
+    }
+
+    /**
+     * @param Rule[] $rules
+     */
+    private static function checkDuplicates(array $rules): void
+    {
+        $targetCounts = self::collectTargetCounts($rules);
+
+        foreach ($targetCounts as $target => $count) {
+            if ($count > 1) {
+                throw new MatchingFailure(
+                    sprintf(
+                        'the target "%s" is declared only once. Found %d declarations',
+                        $target,
+                        $count,
+                    ),
+                );
+            }
+        }
+    }
+
+    /**
+     * @param Rule[] $rules
+     *
+     * @return array<string, positive-int>
+     */
+    private static function collectTargetCounts(array $rules): array
+    {
+        $targetCounts = [];
+
+        foreach ($rules as $rule) {
+            if ($rule->isPhony() || $rule->isComment()) {
+                continue;
+            }
+
+            $target = $rule->getTarget();
+
+            if (array_key_exists($target, $targetCounts)) {
+                ++$targetCounts[$target];
+            } else {
+                $targetCounts[$target] = 1;
+            }
+        }
+
+        return $targetCounts;
+    }
+}

--- a/src/Test/Constraint/SinglePrerequisitePhony.php
+++ b/src/Test/Constraint/SinglePrerequisitePhony.php
@@ -1,0 +1,110 @@
+<?php
+
+/*
+ * This code is licensed under the BSD 3-Clause License.e
+ *
+ * Copyright (c) 2022, Théo FIDRY <theo.fidry@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Fidry\Makefile\Test\Constraint;
+
+use Fidry\Makefile\Rule;
+use function count;
+use function get_debug_type;
+use function Safe\sprintf;
+
+final class SinglePrerequisitePhony extends BaseConstraint
+{
+    public function toString(): string
+    {
+        return 'is a .PHONY rule with one and only one pre-requisite';
+    }
+
+    public function checkOther($other, string $description): void
+    {
+        self::checkIsRuleInstance($other);
+        self::checkIsPhonyRule($other);
+        self::checkHasOnePrerequisite($other);
+    }
+
+    /**
+     * @param mixed $other
+     * @psalm-assert Rule $other
+     *
+     * @throws MatchingFailure
+     */
+    private static function checkIsRuleInstance($other): void
+    {
+        if (!($other instanceof Rule)) {
+            throw new MatchingFailure(
+                sprintf(
+                    'the value to be a "%s" instance. Got "%s"',
+                    Rule::class,
+                    get_debug_type($other),
+                ),
+            );
+        }
+    }
+
+    /**
+     * @throws MatchingFailure
+     */
+    private static function checkIsPhonyRule(Rule $rule): void
+    {
+        if (!$rule->isPhony()) {
+            throw new MatchingFailure(
+                sprintf(
+                    'the rule "%s" is not a .PHONY rule',
+                    $rule->toString(),
+                ),
+            );
+        }
+    }
+
+    /**
+     * @throws MatchingFailure
+     */
+    private static function checkHasOnePrerequisite(Rule $rule): void
+    {
+        $prerequisitesCount = count($rule->getPrerequisites());
+
+        if (1 !== $prerequisitesCount) {
+            throw new MatchingFailure(
+                sprintf(
+                    'the rule "%s" has one and only one pre-requisite. %d pre-requisite%s found',
+                    $rule->toString(),
+                    $prerequisitesCount,
+                    $prerequisitesCount > 1 ? 's' : '',
+                ),
+            );
+        }
+    }
+}

--- a/src/Test/Constraint/ValidCommandDeclaration.php
+++ b/src/Test/Constraint/ValidCommandDeclaration.php
@@ -156,7 +156,7 @@ final class ValidCommandDeclaration extends BaseConstraint
                 sprintf(
                     'the rule "%s" is valid. Cannot have multiple PHONY targets mixed up in a command declaration',
                     $nextRule->toString(),
-                )
+                ),
             );
         }
 

--- a/src/Test/Constraint/ValidCommandDeclaration.php
+++ b/src/Test/Constraint/ValidCommandDeclaration.php
@@ -106,6 +106,7 @@ final class ValidCommandDeclaration extends BaseConstraint
             }
 
             (new SinglePrerequisitePhony())->checkOther($rule, $description);
+            /** @psalm-suppress PossiblyUndefinedIntArrayOffset */
             $phonyTarget = $rule->getPrerequisites()[0];
 
             $nextRule = self::getNextRule($rule, $uncheckedRules);
@@ -139,7 +140,6 @@ final class ValidCommandDeclaration extends BaseConstraint
      */
     private static function getNextRule(Rule $rule, array &$rules): Rule
     {
-        /** @var Rule|null $nextRule */
         $nextRule = array_shift($rules);
 
         if (null === $nextRule) {
@@ -164,7 +164,7 @@ final class ValidCommandDeclaration extends BaseConstraint
     }
 
     private function checkCommandComment(
-        ?Rule $rule,
+        Rule $rule,
         string $phonyTarget,
         string $description
     ): void {
@@ -189,7 +189,7 @@ final class ValidCommandDeclaration extends BaseConstraint
     }
 
     private function checkCommandRule(
-        ?Rule $rule,
+        Rule $rule,
         string $phonyTarget,
         string $description
     ): void {

--- a/src/Test/Constraint/ValidCommandDeclaration.php
+++ b/src/Test/Constraint/ValidCommandDeclaration.php
@@ -1,0 +1,236 @@
+<?php
+
+/*
+ * This code is licensed under the BSD 3-Clause License.e
+ *
+ * Copyright (c) 2022, Théo FIDRY <theo.fidry@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Fidry\Makefile\Test\Constraint;
+
+use Fidry\Makefile\Rule;
+use SebastianBergmann\Comparator\ComparisonFailure;
+use function array_shift;
+use function count;
+use function get_debug_type;
+use function is_array;
+use function Safe\sprintf;
+
+final class ValidCommandDeclaration extends BaseConstraint
+{
+    public function toString(): string
+    {
+        return 'is a Makefile "command" declaration';
+    }
+
+    public function checkOther($other, string $description): void
+    {
+        self::checkIsArrayOfRules($other);
+        $this->checkRules($other, $description);
+    }
+
+    /**
+     * @param mixed $other
+     * @psalm-assert Rule[] $other
+     *
+     * @throws MatchingFailure
+     */
+    private static function checkIsArrayOfRules($other): void
+    {
+        if (!is_array($other)) {
+            throw new MatchingFailure(
+                sprintf(
+                    'the value to be an array of "%s" instances. Got "%s"',
+                    Rule::class,
+                    get_debug_type($other),
+                ),
+            );
+        }
+
+        foreach ($other as $index => $value) {
+            if (!($value instanceof Rule)) {
+                throw new MatchingFailure(
+                    sprintf(
+                        'the value to be an array of "%s" instances. Got "%s" for the item of index "%s"',
+                        Rule::class,
+                        get_debug_type($value),
+                        $index,
+                    ),
+                );
+            }
+        }
+    }
+
+    /**
+     * @param Rule[] $rules
+     */
+    private function checkRules(array $rules, string $description): void
+    {
+        // TODO: add test that it doesn't mutate the rules
+        // TODO: add test for non list rules
+        $uncheckedRules = $rules;
+
+        while (count($uncheckedRules) > 0) {
+            $rule = array_shift($uncheckedRules);
+
+            if (!$rule->isPhony()) {
+                continue;
+            }
+
+            (new SinglePrerequisitePhony())->checkOther($rule, $description);
+            $phonyTarget = $rule->getPrerequisites()[0];
+
+            $nextRule = self::getNextRule($rule, $uncheckedRules);
+
+            if (!$nextRule->isComment()) {
+                $this->checkCommandRule(
+                    $nextRule,
+                    $phonyTarget,
+                    $description,
+                );
+
+                continue;
+            }
+
+            $this->checkCommandComment(
+                $nextRule,
+                $phonyTarget,
+                $description,
+            );
+
+            $this->checkCommandRule(
+                self::getNextRule($rule, $uncheckedRules),
+                $phonyTarget,
+                $description,
+            );
+        }
+    }
+
+    /**
+     * @param Rule[] $rules
+     */
+    private static function getNextRule(Rule $rule, array &$rules): Rule
+    {
+        /** @var Rule|null $nextRule */
+        $nextRule = array_shift($rules);
+
+        if (null === $nextRule) {
+            throw new MatchingFailure(
+                sprintf(
+                    'the rule "%s" is valid. No rule found after its declaration',
+                    $rule->toString(),
+                ),
+            );
+        }
+
+        if ($nextRule->isPhony()) {
+            throw new MatchingFailure(
+                sprintf(
+                    'the rule "%s" is valid. Cannot have multiple PHONY targets mixed up in a command declaration',
+                    $nextRule->toString(),
+                )
+            );
+        }
+
+        return $nextRule;
+    }
+
+    private function checkCommandComment(
+        ?Rule $rule,
+        string $phonyTarget,
+        string $description
+    ): void {
+        $this->checkThatTargetIsMatching(
+            $phonyTarget,
+            $rule->getTarget(),
+            sprintf(
+                'the rule "%s" has the same target as the previous PHONY declaration',
+                $rule->toString(),
+            ),
+            $description,
+        );
+
+        if (!$rule->isCommandComment()) {
+            throw new MatchingFailure(
+                sprintf(
+                    'the rule "%s" is a command help comment. It should either start with "##" to be one or made into a simple Makefile comment (without the target declaration)',
+                    $rule->toString(),
+                ),
+            );
+        }
+    }
+
+    private function checkCommandRule(
+        ?Rule $rule,
+        string $phonyTarget,
+        string $description
+    ): void {
+        $this->checkThatTargetIsMatching(
+            $phonyTarget,
+            $rule->getTarget(),
+            sprintf(
+                'the rule "%s" has the same target as the previous PHONY declaration',
+                $rule->toString(),
+            ),
+            $description,
+        );
+
+        // TODO: test for regular comment
+        if ($rule->isCommandComment()) {
+            throw new MatchingFailure(
+                sprintf(
+                    'the rule "%s" is a command rule. A command should either have no help comment or only one. More than one found',
+                    $rule->toString(),
+                ),
+            );
+        }
+    }
+
+    private function checkThatTargetIsMatching(
+        string $expectedTarget,
+        string $ruleTarget,
+        string $failureDescription,
+        string $description
+    ): void {
+        if ($ruleTarget !== $expectedTarget) {
+            $this->failureDescription = $failureDescription;
+
+            $comparisonFailure = new ComparisonFailure(
+                $expectedTarget,
+                $ruleTarget,
+                $expectedTarget,
+                $ruleTarget,
+            );
+
+            $this->fail(null, $description, $comparisonFailure);
+        }
+    }
+}

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -98,13 +98,13 @@ final class ParserTest extends TestCase
         yield 'simple command with a help comment' => [
             <<<'MAKEFILE'
                 .PHONY: command
-                command:    ## Comment
+                command:    ## Long comment
                 command: foo bar $(DEP)
                     @echo 'Hello'
                 MAKEFILE,
             [
                 new Rule('.PHONY', ['command']),
-                new Rule('command', ['## Comment']),
+                new Rule('command', ['## Long comment']),
                 new Rule('command', ['foo', 'bar', '$(DEP)']),
             ],
         ];
@@ -265,6 +265,15 @@ final class ParserTest extends TestCase
                 MAKEFILE,
             [
                 new Rule('foo', ['bar']),
+            ],
+        ];
+
+        yield 'phony target without target' => [
+            <<<'MAKEFILE'
+                .PHONY:
+                MAKEFILE,
+            [
+                new Rule('.PHONY', []),
             ],
         ];
 

--- a/tests/RuleTest.php
+++ b/tests/RuleTest.php
@@ -158,6 +158,11 @@ final class RuleTest extends TestCase
             Rule::createPhony(['#progA progB']),
             true,
         ];
+
+        yield 'rule with no pre-requisite' => [
+            new Rule('command', []),
+            false,
+        ];
     }
 
     /**
@@ -199,6 +204,11 @@ final class RuleTest extends TestCase
 
         yield 'PHONY rule with Makefile comment' => [
             Rule::createPhony(['#progA progB']),
+            false,
+        ];
+
+        yield 'rule with no pre-requisite' => [
+            new Rule('command', []),
             false,
         ];
     }

--- a/tests/RuleTest.php
+++ b/tests/RuleTest.php
@@ -118,6 +118,92 @@ final class RuleTest extends TestCase
     }
 
     /**
+     * @dataProvider makefileCommentProvider
+     */
+    public function test_it_can_detect_the_rule_is_a_target_with_a_makefile_comment(
+        Rule $rule,
+        bool $expected
+    ): void {
+        self::assertSame($expected, $rule->isComment());
+    }
+
+    public static function makefileCommentProvider(): iterable
+    {
+        yield 'rule' => [
+            new Rule('command', ['progA', 'progB']),
+            false,
+        ];
+
+        yield 'PHONY rule' => [
+            Rule::createPhony(['progA', 'progB']),
+            false,
+        ];
+
+        yield 'rule with Makefile comment' => [
+            new Rule('command', ['#progA progB']),
+            true,
+        ];
+
+        yield 'rule with command comment' => [
+            new Rule('command', ['##progA progB']),
+            true,
+        ];
+
+        yield 'rule with extra comment marker' => [
+            new Rule('command', ['###progA progB']),
+            true,
+        ];
+
+        yield 'PHONY rule with Makefile comment' => [
+            Rule::createPhony(['#progA progB']),
+            true,
+        ];
+    }
+
+    /**
+     * @dataProvider commandCommentProvider
+     */
+    public function test_it_can_detect_the_rule_is_a_target_with_a_command_comment(
+        Rule $rule,
+        bool $expected
+    ): void {
+        self::assertSame($expected, $rule->isCommandComment());
+    }
+
+    public static function commandCommentProvider(): iterable
+    {
+        yield 'rule' => [
+            new Rule('command', ['progA', 'progB']),
+            false,
+        ];
+
+        yield 'PHONY rule' => [
+            Rule::createPhony(['progA', 'progB']),
+            false,
+        ];
+
+        yield 'rule with Makefile comment' => [
+            new Rule('command', ['#progA progB']),
+            false,
+        ];
+
+        yield 'rule with command comment' => [
+            new Rule('command', ['##progA progB']),
+            true,
+        ];
+
+        yield 'rule with extra comment marker' => [
+            new Rule('command', ['###progA progB']),
+            true,
+        ];
+
+        yield 'PHONY rule with Makefile comment' => [
+            Rule::createPhony(['#progA progB']),
+            false,
+        ];
+    }
+
+    /**
      * @param list<string> $expectedPrerequisites
      */
     private static function assertStateIs(

--- a/tests/Test/AssertTest.php
+++ b/tests/Test/AssertTest.php
@@ -60,7 +60,7 @@ final class AssertTest extends TestCase
         Rule $rule,
         ?string $expectedAssertionFailureMessage
     ): void {
-        $assert = static fn () => Assert::assertSinglePrerequisitePhony($rule);
+        $assert = static function () use ($rule): void { Assert::assertSinglePrerequisitePhony($rule); };
 
         if (null === $expectedAssertionFailureMessage) {
             $assert();
@@ -96,7 +96,7 @@ final class AssertTest extends TestCase
         $rules,
         ?string $expectedAssertionFailureMessage
     ): void {
-        $assert = static fn () => Assert::assertHasValidPhonyTargetDeclarations($rules);
+        $assert = static function () use ($rules): void { Assert::assertHasValidPhonyTargetDeclarations($rules); };
 
         if (null === $expectedAssertionFailureMessage) {
             $assert();
@@ -138,7 +138,7 @@ final class AssertTest extends TestCase
         $rules,
         ?string $expectedAssertionFailureMessage
     ): void {
-        $assert = static fn () => Assert::assertNoDuplicateTarget($rules);
+        $assert = static function () use ($rules): void { Assert::assertNoDuplicateTarget($rules); };
 
         if (null === $expectedAssertionFailureMessage) {
             $assert();

--- a/tests/Test/AssertTest.php
+++ b/tests/Test/AssertTest.php
@@ -1,0 +1,196 @@
+<?php
+
+/*
+ * This code is licensed under the BSD 3-Clause License.e
+ *
+ * Copyright (c) 2022, Théo FIDRY <theo.fidry@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Fidry\Makefile\Tests\Test;
+
+use Fidry\Makefile\Rule;
+use Fidry\Makefile\Test\Assert;
+use Fidry\Makefile\Tests\Test\Constraint\NoDuplicateTargetTest;
+use Fidry\Makefile\Tests\Test\Constraint\SinglePrerequisitePhonyTest;
+use Fidry\Makefile\Tests\Test\Constraint\ValidCommandDeclarationTest;
+use Fidry\Makefile\Tests\ThrowableToStringMapper;
+use PHPUnit\Framework\ExpectationFailedException;
+use PHPUnit\Framework\TestCase;
+use function is_array;
+
+/**
+ * @covers \Fidry\Makefile\Test\Assert
+ *
+ * @internal
+ */
+final class AssertTest extends TestCase
+{
+    /**
+     * @dataProvider singlePrerequisitePhonyProvider
+     */
+    public function test_it_tests_that_a_rule_is_phony_and_has_one_and_only_one_pre_requisite(
+        Rule $rule,
+        ?string $expectedAssertionFailureMessage
+    ): void {
+        $assert = static fn () => Assert::assertSinglePrerequisitePhony($rule);
+
+        if (null === $expectedAssertionFailureMessage) {
+            $assert();
+
+            return;
+        }
+
+        self::assertAssertionFails(
+            $assert,
+            $expectedAssertionFailureMessage,
+        );
+    }
+
+    public static function singlePrerequisitePhonyProvider(): iterable
+    {
+        foreach (SinglePrerequisitePhonyTest::valueProvider() as $label => $set) {
+            $rule = $set[0];
+
+            if (!$rule instanceof Rule) {
+                continue;
+            }
+
+            yield $label => $set;
+        }
+    }
+
+    /**
+     * @dataProvider phonyDeclarationsProvider
+     *
+     * @param Rule[] $rules
+     */
+    public function test_it_tests_that_the_phony_declarations_declare_a_command(
+        $rules,
+        ?string $expectedAssertionFailureMessage
+    ): void {
+        $assert = static fn () => Assert::assertHasValidPhonyTargetDeclarations($rules);
+
+        if (null === $expectedAssertionFailureMessage) {
+            $assert();
+
+            return;
+        }
+
+        self::assertAssertionFails(
+            $assert,
+            $expectedAssertionFailureMessage,
+        );
+    }
+
+    public static function phonyDeclarationsProvider(): iterable
+    {
+        foreach (ValidCommandDeclarationTest::valueProvider() as $label => $set) {
+            $rules = $set[0];
+
+            if (!is_array($rules)) {
+                continue;
+            }
+
+            foreach ($rules as $rule) {
+                if (!$rule instanceof Rule) {
+                    continue 2;
+                }
+            }
+
+            yield $label => $set;
+        }
+    }
+
+    /**
+     * @dataProvider duplicateTargetProvider
+     *
+     * @param Rule[] $rules
+     */
+    public function test_it_tests_that_no_target_is_declared_twice(
+        $rules,
+        ?string $expectedAssertionFailureMessage
+    ): void {
+        $assert = static fn () => Assert::assertNoDuplicateTarget($rules);
+
+        if (null === $expectedAssertionFailureMessage) {
+            $assert();
+
+            return;
+        }
+
+        self::assertAssertionFails(
+            static fn () => Assert::assertNoDuplicateTarget($rules),
+            $expectedAssertionFailureMessage,
+        );
+    }
+
+    public static function duplicateTargetProvider(): iterable
+    {
+        foreach (NoDuplicateTargetTest::valueProvider() as $label => $set) {
+            $rules = $set[0];
+
+            if (!is_array($rules)) {
+                continue;
+            }
+
+            foreach ($rules as $rule) {
+                if (!$rule instanceof Rule) {
+                    continue 2;
+                }
+            }
+
+            yield $label => $set;
+        }
+    }
+
+    /**
+     * @param callable():void $assert
+     */
+    private static function assertAssertionFails(
+        callable $assert,
+        string $expectedAssertionFailureMessage
+    ): void {
+        try {
+            $assert();
+        } catch (ExpectationFailedException $assertionFailed) {
+            // Continue
+        }
+
+        if (!isset($assertionFailed)) {
+            self::fail('Expected assertion failure.');
+        }
+
+        self::assertSame(
+            $expectedAssertionFailureMessage,
+            ThrowableToStringMapper::map($assertionFailed),
+        );
+    }
+}

--- a/tests/Test/Constraint/ConstraintTestCase.php
+++ b/tests/Test/Constraint/ConstraintTestCase.php
@@ -69,6 +69,7 @@ abstract class ConstraintTestCase extends TestCase
             // Continue
         }
 
+        /** @psalm-suppress PossiblyUndefinedVariable */
         if (!isset($expectationFailed)) {
             self::fail(
                 sprintf(

--- a/tests/Test/Constraint/ConstraintTestCase.php
+++ b/tests/Test/Constraint/ConstraintTestCase.php
@@ -1,0 +1,86 @@
+<?php
+
+/*
+ * This code is licensed under the BSD 3-Clause License.e
+ *
+ * Copyright (c) 2022, Théo FIDRY <theo.fidry@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Fidry\Makefile\Tests\Test\Constraint;
+
+use Fidry\Makefile\Tests\ThrowableToStringMapper;
+use PHPUnit\Framework\Constraint\Constraint;
+use PHPUnit\Framework\ExpectationFailedException;
+use PHPUnit\Framework\TestCase;
+use function get_debug_type;
+use function sprintf;
+
+abstract class ConstraintTestCase extends TestCase
+{
+    /**
+     * @param mixed $other
+     */
+    final protected static function assertConstraintDoesNotFail(Constraint $constraint, $other): void
+    {
+        $result = $constraint->evaluate($other);
+
+        self::assertNull($result);
+    }
+
+    /**
+     * @param mixed $other
+     */
+    final protected static function assertConstraintFails(
+        Constraint $constraint,
+        $other,
+        string $expectedAssertionFailureMessage
+    ): void {
+        try {
+            $result = $constraint->evaluate($other);
+        } catch (ExpectationFailedException $expectationFailed) {
+            // Continue
+        }
+
+        if (!isset($expectationFailed)) {
+            self::fail(
+                sprintf(
+                    'Expected assertion failure. The evaluation of the constraint returned "%s"',
+                    get_debug_type($result),
+                ),
+            );
+        }
+
+        self::assertSame(
+            $expectedAssertionFailureMessage,
+            ThrowableToStringMapper::map($expectationFailed),
+        );
+    }
+}

--- a/tests/Test/Constraint/NoDuplicateTargetTest.php
+++ b/tests/Test/Constraint/NoDuplicateTargetTest.php
@@ -124,5 +124,41 @@ final class NoDuplicateTargetTest extends ConstraintTestCase
             ],
             null,
         ];
+
+        yield 'target declared twice with other rules in-between' => [
+            [
+                new Rule('command1', ['progA']),
+                new Rule('command2', ['progB']),
+                new Rule('command1', ['progC']),
+            ],
+            <<<'EOF'
+                Failed asserting that the target "command1" is declared only once. Found 2 declarations.
+
+                EOF,
+        ];
+
+        yield 'target declared twice with other rules before' => [
+            [
+                new Rule('command2', ['progB']),
+                new Rule('command1', ['progA']),
+                new Rule('command1', ['progC']),
+            ],
+            <<<'EOF'
+                Failed asserting that the target "command1" is declared only once. Found 2 declarations.
+
+                EOF,
+        ];
+
+        yield 'target declared twice with a comment in-between' => [
+            [
+                new Rule('command1', ['progA']),
+                new Rule('command2', ['## progB']),
+                new Rule('command1', ['progC']),
+            ],
+            <<<'EOF'
+                Failed asserting that the target "command1" is declared only once. Found 2 declarations.
+
+                EOF,
+        ];
     }
 }

--- a/tests/Test/Constraint/NoDuplicateTargetTest.php
+++ b/tests/Test/Constraint/NoDuplicateTargetTest.php
@@ -1,0 +1,128 @@
+<?php
+
+/*
+ * This code is licensed under the BSD 3-Clause License.e
+ *
+ * Copyright (c) 2022, Théo FIDRY <theo.fidry@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Fidry\Makefile\Tests\Test\Constraint;
+
+use Fidry\Makefile\Rule;
+use Fidry\Makefile\Test\Constraint\NoDuplicateTarget;
+use stdClass;
+
+/**
+ * @covers \Fidry\Makefile\Test\Constraint\NoDuplicateTarget
+ *
+ * @internal
+ */
+final class NoDuplicateTargetTest extends ConstraintTestCase
+{
+    /**
+     * @dataProvider valueProvider
+     *
+     * @param mixed $value
+     */
+    public function test_it_tests_that_no_target_is_declared_twice(
+        $value,
+        ?string $expectedExpectationFailureMessage
+    ): void {
+        $constraint = new NoDuplicateTarget();
+
+        null === $expectedExpectationFailureMessage
+            ? self::assertConstraintDoesNotFail($constraint, $value)
+            : self::assertConstraintFails($constraint, $value, $expectedExpectationFailureMessage);
+    }
+
+    public static function valueProvider(): iterable
+    {
+        yield 'non array value' => [
+            new stdClass(),
+            <<<'EOF'
+                Failed asserting that the value to be an array of "Fidry\Makefile\Rule" instances. Got "stdClass".
+
+                EOF,
+        ];
+
+        yield 'no rules' => [
+            [],
+            null,
+        ];
+
+        yield 'array of non-rule value' => [
+            [
+                new Rule('foo', []),
+                new stdClass(),
+            ],
+            <<<'EOF'
+                Failed asserting that the value to be an array of "Fidry\Makefile\Rule" instances. Got "stdClass" for the item of index "1".
+
+                EOF,
+        ];
+
+        yield 'target declared twice but with one occurrence being a comment' => [
+            [
+                new Rule('command', ['## Command Help']),
+                new Rule('command', ['progA', 'progB']),
+            ],
+            null,
+        ];
+
+        yield 'two distinct targets' => [
+            [
+                new Rule('command1', ['progA', 'progB']),
+                new Rule('command2', ['progA', 'progC']),
+            ],
+            null,
+        ];
+
+        yield 'target declared 3 times' => [
+            [
+                new Rule('command1', ['progA']),
+                new Rule('command1', ['progB']),
+                new Rule('command1', ['progC']),
+            ],
+            <<<'EOF'
+                Failed asserting that the target "command1" is declared only once. Found 3 declarations.
+
+                EOF,
+        ];
+
+        yield 'PHONY target declared twice' => [
+            [
+                Rule::createPhony(['command1']),
+                Rule::createPhony(['command1']),
+            ],
+            null,
+        ];
+    }
+}

--- a/tests/Test/Constraint/SinglePrerequisitePhonyTest.php
+++ b/tests/Test/Constraint/SinglePrerequisitePhonyTest.php
@@ -1,0 +1,105 @@
+<?php
+
+/*
+ * This code is licensed under the BSD 3-Clause License.e
+ *
+ * Copyright (c) 2022, Théo FIDRY <theo.fidry@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Fidry\Makefile\Tests\Test\Constraint;
+
+use Fidry\Makefile\Rule;
+use Fidry\Makefile\Test\Constraint\SinglePrerequisitePhony;
+use stdClass;
+
+/**
+ * @covers \Fidry\Makefile\Test\Constraint\SinglePrerequisitePhony
+ *
+ * @internal
+ */
+final class SinglePrerequisitePhonyTest extends ConstraintTestCase
+{
+    /**
+     * @dataProvider valueProvider
+     *
+     * @param mixed $value
+     */
+    public function test_it_tests_that_a_rule_is_phony_and_has_one_and_only_one_pre_requisite(
+        $value,
+        ?string $expectedExpectationFailureMessage
+    ): void {
+        $constraint = new SinglePrerequisitePhony();
+
+        null === $expectedExpectationFailureMessage
+            ? self::assertConstraintDoesNotFail($constraint, $value)
+            : self::assertConstraintFails($constraint, $value, $expectedExpectationFailureMessage);
+    }
+
+    public static function valueProvider(): iterable
+    {
+        yield 'nominal' => [
+            Rule::createPhony(['command']),
+            null,
+        ];
+
+        yield 'empty PHONY target' => [
+            Rule::createPhony([]),
+            <<<'EOF'
+                Failed asserting that the rule ".PHONY: " has one and only one pre-requisite. 0 pre-requisite found.
+
+                EOF,
+        ];
+
+        yield 'PHONY target with multiple targets' => [
+            Rule::createPhony(['command1', 'command2']),
+            <<<'EOF'
+                Failed asserting that the rule ".PHONY: command1 command2" has one and only one pre-requisite. 2 pre-requisites found.
+
+                EOF,
+        ];
+
+        yield 'non phony rule' => [
+            new Rule('command', ['object']),
+            <<<'EOF'
+                Failed asserting that the rule "command: object" is not a .PHONY rule.
+
+                EOF,
+        ];
+
+        yield 'non rule object' => [
+            new stdClass(),
+            <<<'EOF'
+                Failed asserting that the value to be a "Fidry\Makefile\Rule" instance. Got "stdClass".
+
+                EOF,
+        ];
+    }
+}

--- a/tests/Test/Constraint/ValidCommandDeclarationTest.php
+++ b/tests/Test/Constraint/ValidCommandDeclarationTest.php
@@ -146,7 +146,43 @@ final class ValidCommandDeclarationTest extends ConstraintTestCase
             null,
         ];
 
-        // TODO: add tests for PHONY with comments: first PHONY is a comment, 2nd rule is a comment but a PHONY one...
+        yield 'command declaration with an invalid command afterwards' => [
+            [
+                Rule::createPhony(['command1']),
+                new Rule('command1', ['progA', 'progB']),
+
+                Rule::createPhony(['command2']),
+                new Rule('command3', []),
+            ],
+            <<<'EOF'
+                Failed asserting that the rule "command3: " has the same target as the previous PHONY declaration.
+                --- Expected
+                +++ Actual
+                @@ @@
+                -command2
+                +command3
+
+                EOF,
+        ];
+
+        yield 'invalid command after non phony target' => [
+            [
+                new Rule('command', ['progA', 'progB']),
+
+                Rule::createPhony(['command2']),
+                new Rule('command3', []),
+            ],
+            <<<'EOF'
+                Failed asserting that the rule "command3: " has the same target as the previous PHONY declaration.
+                --- Expected
+                +++ Actual
+                @@ @@
+                -command2
+                +command3
+
+                EOF,
+        ];
+
         yield 'two PHONY targets' => [
             [
                 Rule::createPhony(['command1']),

--- a/tests/Test/Constraint/ValidCommandDeclarationTest.php
+++ b/tests/Test/Constraint/ValidCommandDeclarationTest.php
@@ -1,0 +1,280 @@
+<?php
+
+/*
+ * This code is licensed under the BSD 3-Clause License.e
+ *
+ * Copyright (c) 2022, Théo FIDRY <theo.fidry@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Fidry\Makefile\Tests\Test\Constraint;
+
+use Fidry\Makefile\Rule;
+use Fidry\Makefile\Test\Constraint\ValidCommandDeclaration;
+use stdClass;
+
+/**
+ * @covers \Fidry\Makefile\Test\Constraint\ValidCommandDeclaration
+ *
+ * @internal
+ */
+final class ValidCommandDeclarationTest extends ConstraintTestCase
+{
+    /**
+     * @dataProvider valueProvider
+     *
+     * @param mixed $value
+     */
+    public function test_it_tests_that_the_phony_declarations_declare_a_command(
+        $value,
+        ?string $expectedExpectationFailureMessage
+    ): void {
+        $constraint = new ValidCommandDeclaration();
+
+        null === $expectedExpectationFailureMessage
+            ? self::assertConstraintDoesNotFail($constraint, $value)
+            : self::assertConstraintFails($constraint, $value, $expectedExpectationFailureMessage);
+    }
+
+    public static function valueProvider(): iterable
+    {
+        yield 'non array value' => [
+            new stdClass(),
+            <<<'EOF'
+                Failed asserting that the value to be an array of "Fidry\Makefile\Rule" instances. Got "stdClass".
+
+                EOF,
+        ];
+
+        yield 'no rules' => [
+            [],
+            null,
+        ];
+
+        yield 'array of non-rule value' => [
+            [
+                new Rule('foo', []),
+                new stdClass(),
+            ],
+            <<<'EOF'
+                Failed asserting that the value to be an array of "Fidry\Makefile\Rule" instances. Got "stdClass" for the item of index "1".
+
+                EOF,
+        ];
+
+        yield 'single command' => [
+            [
+                Rule::createPhony(['command']),
+                new Rule('command', ['## Command Help']),
+                new Rule('command', ['progA', 'progB']),
+            ],
+            null,
+        ];
+
+        yield 'two commands' => [
+            [
+                Rule::createPhony(['command1']),
+                new Rule('command1', ['## Command1 Help']),
+                new Rule('command1', ['progA', 'progB']),
+
+                Rule::createPhony(['command2']),
+                new Rule('command2', ['## Command2 Help']),
+                new Rule('command2', ['progA', 'progC']),
+            ],
+            null,
+        ];
+
+        yield 'PHONY declaration with no pre-requisites' => [
+            [
+                Rule::createPhony([]),
+            ],
+            <<<'EOF'
+                Failed asserting that the rule ".PHONY: " has one and only one pre-requisite. 0 pre-requisite found.
+
+                EOF,
+        ];
+
+        yield 'PHONY declaration referencing a different target that the command declared thereafter' => [
+            [
+                Rule::createPhony(['command2']),
+                new Rule('command1', ['## Command1 Help']),
+                new Rule('command1', ['progA', 'progB']),
+            ],
+            <<<'EOF'
+                Failed asserting that the rule "command1: ## Command1 Help" has the same target as the previous PHONY declaration.
+                --- Expected
+                +++ Actual
+                @@ @@
+                -command2
+                +command1
+
+                EOF,
+        ];
+
+        yield 'command declaration without a help comment' => [
+            [
+                Rule::createPhony(['command1']),
+                new Rule('command1', ['progA', 'progB']),
+            ],
+            null,
+        ];
+
+        // TODO: add tests for PHONY with comments: first PHONY is a comment, 2nd rule is a comment but a PHONY one...
+        yield 'two PHONY targets' => [
+            [
+                Rule::createPhony(['command1']),
+                Rule::createPhony(['command2']),
+            ],
+            <<<'EOF'
+                Failed asserting that the rule ".PHONY: command2" is valid. Cannot have multiple PHONY targets mixed up in a command declaration.
+
+                EOF,
+        ];
+
+        yield 'two PHONY targets with the 2nd being a comment' => [
+            [
+                Rule::createPhony(['command1']),
+                Rule::createPhony(['## command2']),
+            ],
+            <<<'EOF'
+                Failed asserting that the rule ".PHONY: ## command2" is valid. Cannot have multiple PHONY targets mixed up in a command declaration.
+
+                EOF,
+        ];
+
+        yield 'two PHONY targets with the 2nd being where a command should be' => [
+            [
+                Rule::createPhony(['command1']),
+                new Rule('command1', ['## Command1 Help']),
+                Rule::createPhony(['command1']),
+            ],
+            <<<'EOF'
+                Failed asserting that the rule ".PHONY: command1" is valid. Cannot have multiple PHONY targets mixed up in a command declaration.
+
+                EOF,
+        ];
+
+        yield 'PHONY declaration with a help comment but no command' => [
+            [
+                Rule::createPhony(['command1']),
+                new Rule('command1', ['## Command1 Help']),
+            ],
+            <<<'EOF'
+                Failed asserting that the rule ".PHONY: command1" is valid. No rule found after its declaration.
+
+                EOF,
+        ];
+
+        yield 'PHONY declaration without a help comment neither a command' => [
+            [
+                Rule::createPhony(['command1']),
+            ],
+            <<<'EOF'
+                Failed asserting that the rule ".PHONY: command1" is valid. No rule found after its declaration.
+
+                EOF,
+        ];
+
+        yield 'command declaration with the help comment designating the wrong target' => [
+            [
+                Rule::createPhony(['command1']),
+                new Rule('command2', ['## Command2 Help']),
+                new Rule('command1', ['progA', 'progB']),
+            ],
+            <<<'EOF'
+                Failed asserting that the rule "command2: ## Command2 Help" has the same target as the previous PHONY declaration.
+                --- Expected
+                +++ Actual
+                @@ @@
+                -command1
+                +command2
+
+                EOF,
+        ];
+
+        yield 'command declaration with the command designating the wrong target' => [
+            [
+                Rule::createPhony(['command1']),
+                new Rule('command1', ['## Command1 Help']),
+                new Rule('command2', ['progA', 'progB']),
+            ],
+            <<<'EOF'
+                Failed asserting that the rule "command2: progA progB" has the same target as the previous PHONY declaration.
+                --- Expected
+                +++ Actual
+                @@ @@
+                -command1
+                +command2
+
+                EOF,
+        ];
+
+        yield 'the command comment is not a command comment' => [
+            [
+                Rule::createPhony(['command1']),
+                new Rule('command1', ['# Command1 Help']),
+                new Rule('command1', ['progA', 'progB']),
+            ],
+            <<<'EOF'
+                Failed asserting that the rule "command1: # Command1 Help" is a command help comment. It should either start with "##" to be one or made into a simple Makefile comment (without the target declaration).
+
+                EOF,
+        ];
+
+        yield 'command with two help commands' => [
+            [
+                Rule::createPhony(['command1']),
+                new Rule('command1', ['## Command1 Help1']),
+                new Rule('command1', ['## Command1 Help2']),
+                new Rule('command1', ['progA', 'progB']),
+            ],
+            <<<'EOF'
+                Failed asserting that the rule "command1: ## Command1 Help2" is a command rule. A command should either have no help comment or only one. More than one found.
+
+                EOF,
+        ];
+
+        yield 'non PHONY command' => [
+            [
+                new Rule('command', ['## Command Help']),
+                new Rule('command', ['progA', 'progB']),
+            ],
+            null,
+        ];
+
+        yield 'non PHONY command with invalid comment' => [
+            [
+                new Rule('command1', ['## Command1 Help']),
+                new Rule('command', ['progA', 'progB']),
+            ],
+            null,
+        ];
+    }
+}

--- a/tests/ThrowableToStringMapper.php
+++ b/tests/ThrowableToStringMapper.php
@@ -66,7 +66,7 @@ final class ThrowableToStringMapper
 
         return sprintf(
             "%s: %s\n",
-            $throwable::class,
+            get_class($throwable),
             $throwable->getMessage(),
         );
     }

--- a/tests/ThrowableToStringMapper.php
+++ b/tests/ThrowableToStringMapper.php
@@ -66,7 +66,7 @@ final class ThrowableToStringMapper
 
         return sprintf(
             "%s: %s\n",
-            get_class($throwable),
+            $throwable::class,
             $throwable->getMessage(),
         );
     }

--- a/tests/ThrowableToStringMapper.php
+++ b/tests/ThrowableToStringMapper.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * This code is licensed under the BSD 3-Clause License.e
+ *
+ * Copyright (c) 2022, Théo FIDRY <theo.fidry@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Fidry\Makefile\Tests;
+
+use PHPUnit\Framework\ExpectationFailedException;
+use PHPUnit\Framework\PHPTAssertionFailedError;
+use PHPUnit\Framework\SelfDescribing;
+use Throwable;
+use function sprintf;
+
+final class ThrowableToStringMapper
+{
+    public static function map(Throwable $throwable): string
+    {
+        if ($throwable instanceof SelfDescribing) {
+            $buffer = $throwable->toString();
+
+            if ($throwable instanceof ExpectationFailedException && $throwable->getComparisonFailure()) {
+                $buffer .= $throwable->getComparisonFailure()->getDiff();
+            }
+
+            if ($throwable instanceof PhptAssertionFailedError) {
+                $buffer .= $throwable->getDiff();
+            }
+
+            if (!empty($buffer)) {
+                $buffer = trim($buffer)."\n";
+            }
+
+            return $buffer;
+        }
+
+        return sprintf(
+            "%s: %s\n",
+            $throwable::class,
+            $throwable->getMessage(),
+        );
+    }
+
+    private function __construct()
+    {
+    }
+}


### PR DESCRIPTION
Instead of doing everything within an abstract test case which makes it harder to test, extend, customize and provide more helpful messages for, everything is being moved to PHPUnit constraints.