### PR TITLE
Fix executing the make help command in a different working directory

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
     tests:
         runs-on: "ubuntu-latest"
-        name: "Test ${{ matrix.php }}"
+        name: "Tests with PHP ${{ matrix.php }}"
         strategy:
             fail-fast: true
             matrix:
@@ -32,4 +32,30 @@ jobs:
                 uses: "ramsey/composer-install@v2"
 
             -   name: "Run tests"
+                run: "make phpunit"
+
+    infection:
+        runs-on: "ubuntu-latest"
+        name: "Infection with PHP ${{ matrix.php }}"
+        strategy:
+            fail-fast: true
+            matrix:
+                php:
+                    - "8.1"
+
+        steps:
+            -   name: "Check out repository code"
+                uses: "actions/checkout@v2"
+
+            -   name: "Setup PHP"
+                uses: "shivammathur/setup-php@v2"
+                with:
+                    php-version: "${{ matrix.php }}"
+                    tools: "composer"
+                    coverage: "pcov"
+
+            -   name: "Install Composer dependencies"
+                uses: "ramsey/composer-install@v2"
+
+            -   name: "Run tests and mutation testing"
                 run: "make infection"

--- a/tests/Feature/WorkingDirectoryMakefileTest.php
+++ b/tests/Feature/WorkingDirectoryMakefileTest.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This code is licensed under the BSD 3-Clause License.e
+ *
+ * Copyright (c) 2022, Théo FIDRY <theo.fidry@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Fidry\Makefile\Tests\Feature;
+
+use Fidry\Makefile\Test\BaseMakefileTestCase;
+
+/**
+ * @internal
+ */
+final class WorkingDirectoryMakefileTest extends BaseMakefileTestCase
+{
+    protected static function getMakefilePath(): string
+    {
+        return __DIR__.'/../Fixtures/Set000/Makefile';
+    }
+
+    protected function getExpectedHelpOutput(): string
+    {
+        return <<<'EOF'
+            ./Makefile ./README.md
+        
+            EOF;
+    }
+}

--- a/tests/Feature/WorkingDirectoryMakefileTest.php
+++ b/tests/Feature/WorkingDirectoryMakefileTest.php
@@ -51,8 +51,8 @@ final class WorkingDirectoryMakefileTest extends BaseMakefileTestCase
     protected function getExpectedHelpOutput(): string
     {
         return <<<'EOF'
-            ./Makefile ./README.md
-        
+            ./README.md
+
             EOF;
     }
 }

--- a/tests/Fixtures/Set000/Makefile
+++ b/tests/Fixtures/Set000/Makefile
@@ -1,0 +1,9 @@
+MAKEFLAGS += --warn-undefined-variables
+MAKEFLAGS += --no-builtin-rules
+
+# This is the problematic code: this command will no longer work as expected as
+# soon as the working directory changes.
+FILES = $(shell find . -type f | sed 's/ /\\ /g')
+
+help:
+	@echo $(FILES)

--- a/tests/Fixtures/Set000/Makefile
+++ b/tests/Fixtures/Set000/Makefile
@@ -3,7 +3,7 @@ MAKEFLAGS += --no-builtin-rules
 
 # This is the problematic code: this command will no longer work as expected as
 # soon as the working directory changes.
-FILES = $(shell find . -type f | sed 's/ /\\ /g')
+FILES = $(shell find . -name '*.md' -type f | sed 's/ /\\ /g')
 
 help:
 	@echo $(FILES)

--- a/tests/Fixtures/Set000/README.md
+++ b/tests/Fixtures/Set000/README.md
@@ -1,0 +1,2 @@
+This test is about showing the necessity of the Makefile to be executed with
+its directory as the working directory.


### PR DESCRIPTION
When executing the makefile command from a different working directory, which was the case for testing the `help` command, shell commands used in the Makefile may behave differently (see the scenario added).

To avoid any weird behaviour, the `help` command is tested by executing the make command within the working directory in which the Makefile file can be found.