### PR TITLE
Fix CI infection execution

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -26,7 +26,6 @@ jobs:
                 with:
                     php-version: "${{ matrix.php }}"
                     tools: "composer"
-                    coverage: "pcov"
 
             -   name: "Install Composer dependencies"
                 uses: "ramsey/composer-install@v2"
@@ -52,7 +51,7 @@ jobs:
                 with:
                     php-version: "${{ matrix.php }}"
                     tools: "composer"
-                    coverage: "pcov"
+                    coverage: "xdebug"
 
             -   name: "Install Composer dependencies"
                 uses: "ramsey/composer-install@v2"

--- a/infection.json.dist
+++ b/infection.json.dist
@@ -14,9 +14,25 @@
         "@default": true,
         "MBString": false,
 
+        "FunctionCallRemoval": {
+            "ignore": [
+                "Fidry\\Makefile\\Test\\BaseMakefileTestCase::executeInDirectory"
+            ]
+        },
         "GreaterThan": {
             "ignore": [
                 "Fidry\\Makefile\\Test\\Constraint\\SinglePrerequisitePhony::checkHasOnePrerequisite"
+            ]
+        },
+        "MethodCallRemoval": {
+            "ignore": [
+                "Fidry\\Makefile\\Test\\BaseMakefileTestCase::getTimeout"
+            ]
+        },
+        "PublicVisibility": false,
+        "UnwrapFinally": {
+            "ignore": [
+                "Fidry\\Makefile\\Test\\BaseMakefileTestCase::executeInDirectory"
             ]
         }
     }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -28,5 +28,9 @@
         <include>
             <directory>src</directory>
         </include>
+
+        <exclude>
+            <file>src/Test/Constraint/BaseConstraint.php</file>
+        </exclude>
     </coverage>
 </phpunit>

--- a/src/Rule.php
+++ b/src/Rule.php
@@ -38,6 +38,7 @@ namespace Fidry\Makefile;
 
 use function current;
 use function implode;
+use function rtrim;
 use function sprintf;
 use function str_starts_with;
 
@@ -125,10 +126,12 @@ final class Rule
 
     public function toString(): string
     {
-        return sprintf(
-            '%s: %s',
-            $this->target,
-            implode(' ', $this->prerequisites),
+        return rtrim(
+            sprintf(
+                '%s: %s',
+                $this->target,
+                implode(' ', $this->prerequisites),
+            ),
         );
     }
 }

--- a/tests/RuleTest.php
+++ b/tests/RuleTest.php
@@ -213,6 +213,38 @@ final class RuleTest extends TestCase
         ];
     }
 
+    public function test_it_can_create_a_phony_rule(): void
+    {
+        $rule = Rule::createPhony(['progA', 'progB']);
+
+        self::assertTrue($rule->isPhony());
+    }
+
+    /**
+     * @dataProvider ruleToStringProvider
+     */
+    public function test_it_can_be_casted_into_a_string(
+        Rule $rule,
+        string $expected
+    ): void {
+        $actual = $rule->toString();
+
+        self::assertSame($expected, $actual);
+    }
+
+    public static function ruleToStringProvider(): iterable
+    {
+        yield 'rule without pre-requisites' => [
+            new Rule('cmd', []),
+            'cmd:',
+        ];
+
+        yield 'rule with pre-requisites' => [
+            new Rule('cmd', ['progA', 'progB']),
+            'cmd: progA progB',
+        ];
+    }
+
     /**
      * @param list<string> $expectedPrerequisites
      */

--- a/tests/Test/Constraint/SinglePrerequisitePhonyTest.php
+++ b/tests/Test/Constraint/SinglePrerequisitePhonyTest.php
@@ -73,7 +73,7 @@ final class SinglePrerequisitePhonyTest extends ConstraintTestCase
         yield 'empty PHONY target' => [
             Rule::createPhony([]),
             <<<'EOF'
-                Failed asserting that the rule ".PHONY: " has one and only one pre-requisite. 0 pre-requisite found.
+                Failed asserting that the rule ".PHONY:" has one and only one pre-requisite. 0 pre-requisite found.
 
                 EOF,
         ];

--- a/tests/Test/Constraint/ValidCommandDeclarationTest.php
+++ b/tests/Test/Constraint/ValidCommandDeclarationTest.php
@@ -116,7 +116,7 @@ final class ValidCommandDeclarationTest extends ConstraintTestCase
                 Rule::createPhony([]),
             ],
             <<<'EOF'
-                Failed asserting that the rule ".PHONY: " has one and only one pre-requisite. 0 pre-requisite found.
+                Failed asserting that the rule ".PHONY:" has one and only one pre-requisite. 0 pre-requisite found.
 
                 EOF,
         ];
@@ -155,7 +155,7 @@ final class ValidCommandDeclarationTest extends ConstraintTestCase
                 new Rule('command3', []),
             ],
             <<<'EOF'
-                Failed asserting that the rule "command3: " has the same target as the previous PHONY declaration.
+                Failed asserting that the rule "command3:" has the same target as the previous PHONY declaration.
                 --- Expected
                 +++ Actual
                 @@ @@
@@ -173,7 +173,7 @@ final class ValidCommandDeclarationTest extends ConstraintTestCase
                 new Rule('command3', []),
             ],
             <<<'EOF'
-                Failed asserting that the rule "command3: " has the same target as the previous PHONY declaration.
+                Failed asserting that the rule "command3:" has the same target as the previous PHONY declaration.
                 --- Expected
                 +++ Actual
                 @@ @@


### PR DESCRIPTION
- Do not install `pcov` for the PHPUnit tests (no coverage needed)
- Use `Xdebug` instead of `pcov` (it is more accurate)
- Add missing test coverage
- Fill in the false-positives reported