### PR TITLE
fix: Ensure the debug flag is not forwarded

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -36,6 +36,31 @@ jobs:
             -   name: "Run tests"
                 run: "make phpunit"
 
+    debug-test:
+        runs-on: "ubuntu-latest"
+        name: "Tests with PHP ${{ matrix.php }} and the make `--debug` flag"
+        strategy:
+            fail-fast: true
+            matrix:
+                php:
+                    - "8.1"
+
+        steps:
+            -   name: "Check out repository code"
+                uses: "actions/checkout@v4"
+
+            -   name: "Setup PHP"
+                uses: "shivammathur/setup-php@v2"
+                with:
+                    php-version: "${{ matrix.php }}"
+                    tools: "composer"
+
+            -   name: "Install Composer dependencies"
+                uses: "ramsey/composer-install@v2"
+
+            -   name: "Run tests"
+                run: "make phpunit --debug"
+
     infection:
         runs-on: "ubuntu-latest"
         name: "Infection with PHP ${{ matrix.php }}"
@@ -70,6 +95,7 @@ jobs:
         runs-on: ubuntu-latest
         needs:
             - tests
+            - debug-test
             - infection
         if: always()
         steps:

--- a/infection.json5.dist
+++ b/infection.json5.dist
@@ -14,6 +14,12 @@
         "@default": true,
         "MBString": false,
 
+        "CastString": {
+            "ignore": [
+                // Testing that getenv() does not return a string is difficult there.
+                "Fidry\\Makefile\\Test\\BaseMakefileTestCase::getNonDebugMakeFlags"
+            ]
+        },
         "FunctionCallRemoval": {
             "ignore": [
                 "Fidry\\Makefile\\Test\\BaseMakefileTestCase::executeInDirectory"

--- a/infection.json5.dist
+++ b/infection.json5.dist
@@ -13,6 +13,9 @@
     "mutators": {
         "@default": true,
         "MBString": false,
+        "global-ignore": [
+            "Fidry\\Makefile\\Test\\BaseMakefileTestCase::getNonDebugMakeFlags"
+        ],
 
         "CastString": {
             "ignore": [
@@ -22,6 +25,7 @@
         },
         "FunctionCallRemoval": {
             "ignore": [
+                "Fidry\\Makefile\\Test\\BaseMakefileTestCase::executeCommand",
                 "Fidry\\Makefile\\Test\\BaseMakefileTestCase::executeInDirectory"
             ]
         },

--- a/src/Test/BaseMakefileTestCase.php
+++ b/src/Test/BaseMakefileTestCase.php
@@ -40,9 +40,13 @@ use Fidry\Makefile\Parser;
 use Fidry\Makefile\Rule;
 use PHPUnit\Framework\TestCase;
 use Safe\Exceptions\ExecException;
+use function array_filter;
 use function dirname;
 use function error_clear_last;
+use function explode;
 use function function_exists;
+use function getenv;
+use function implode;
 use function Safe\chdir;
 use function Safe\file_get_contents;
 use function Safe\getcwd;
@@ -129,6 +133,12 @@ abstract class BaseMakefileTestCase extends TestCase
     // TODO: remove this as we remove support for PHP 7.4 and Safe v1
     final protected static function executeCommand(string $command): string
     {
+        $command = sprintf(
+            'MAKEFLAGS=%s %s',
+            self::getNonDebugMakeFlags(),
+            $command,
+        );
+
         if (function_exists('Safe\shell_exec')) {
             return shell_exec($command);
         }
@@ -142,6 +152,18 @@ abstract class BaseMakefileTestCase extends TestCase
         }
 
         return $safeResult;
+    }
+
+    final protected static function getNonDebugMakeFlags(): string
+    {
+        $makeFlags = (string) getenv('MAKEFLAGS');
+
+        $nonDebugFlags = array_filter(
+            explode(' ', $makeFlags),
+            static fn (string $flag) => str_starts_with('--debug=', $flag),
+        );
+
+        return implode(' ', $nonDebugFlags);
     }
 
     private static function getTimeout(): string

--- a/src/Test/BaseMakefileTestCase.php
+++ b/src/Test/BaseMakefileTestCase.php
@@ -134,7 +134,7 @@ abstract class BaseMakefileTestCase extends TestCase
     final protected static function executeCommand(string $command): string
     {
         $command = sprintf(
-            'MAKEFLAGS=%s %s',
+            'MAKEFLAGS="%s" %s',
             self::getNonDebugMakeFlags(),
             $command,
         );
@@ -160,7 +160,7 @@ abstract class BaseMakefileTestCase extends TestCase
 
         $nonDebugFlags = array_filter(
             explode(' ', $makeFlags),
-            static fn (string $flag) => str_starts_with('--debug=', $flag),
+            static fn (string $flag) => !str_starts_with($flag, '--debug='),
         );
 
         return implode(' ', $nonDebugFlags);


### PR DESCRIPTION
If the PHPUnit test is executed via a Makefile command with the `--debug` flag, for example for this library:

```
make phpunit --debug
```

Then the `MAKEFLAGS` environment variable is updated and forwarded to the processes in which the test make commands are executed. This result in a different output which can easily break tests.