### PR TITLE
Allow thecodingmachine/safe v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "php": "^8.1",
-        "thecodingmachine/safe": "^2.0"
+        "thecodingmachine/safe": "^2.0 || ^3.0"
     },
     "require-dev": {
         "bamarni/composer-bin-plugin": "^1.4",


### PR DESCRIPTION
We need to replace `shish/safe` back to `thecodingmachine/safe`, see https://github.com/infection/infection/pull/2017#issuecomment-2651976954

However, it's not possible right now because Infection depends on this repo in this repo requires `thecodingmachine/safe` v2.

So allowing v3 should unblock us.

```
  Problem 1
    - Root composer.json requires thecodingmachine/safe ^v3.0, found thecodingmachine/safe[v3.0.0] but these were not loaded, likely because it conflicts with another require.
  Problem 2
    - fidry/makefile is locked to version 1.0.2 and an update of this package was not requested.
    - fidry/makefile 1.0.2 requires thecodingmachine/safe ^2.0 -> found thecodingmachine/safe[2.0, ..., v2.5.0] but it conflicts with your root composer.json require (^v3.0).
```