### PR TITLE
feat: Bump min PHP version supported to PHP 8.3

### DIFF
--- a/.github/workflows/cs.yaml
+++ b/.github/workflows/cs.yaml
@@ -21,7 +21,7 @@ jobs:
                     # To also adjust the PHP version in the following files:
                     # - vendor-bin/php-cs-fixer/composer.json
                     # - vendor-bin/rector/composer.json
-                    - "8.1"
+                    - "8.3"
 
         steps:
             -   name: "Check out repository code"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -17,13 +17,11 @@ jobs:
             fail-fast: true
             matrix:
                 php:
-                    - "8.1"
-                    - "8.2"
                     - "8.3"
                     - "8.4"
                 debug: [false]
                 include:
-                    - php: "8.1"
+                    - php: "8.3"
                       debug: true
 
         steps:

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require": {
-        "php": "^8.1"
+        "php": "^8.3"
     },
     "require-dev": {
         "bamarni/composer-bin-plugin": "^1.4",

--- a/psalm.xml
+++ b/psalm.xml
@@ -12,7 +12,7 @@
         findUnusedVariablesAndParams="true"
         ensureArrayStringOffsetsExist="true"
         ensureArrayIntOffsetsExist="true"
-        phpVersion="8.1">
+        phpVersion="8.3">
 
     <plugins>
         <pluginClass class="Psalm\PhpUnitPlugin\Plugin" />

--- a/vendor-bin/php-cs-fixer/composer.json
+++ b/vendor-bin/php-cs-fixer/composer.json
@@ -4,6 +4,6 @@
         "fidry/php-cs-fixer-config": "^1.0"
     },
     "platform": {
-        "php": "8.1"
+        "php": "8.3"
     }
 }

--- a/vendor-bin/rector/composer.json
+++ b/vendor-bin/rector/composer.json
@@ -4,7 +4,7 @@
     },
     "config": {
         "platform": {
-            "php": "8.1"
+            "php": "8.3"
         }
     }
 }


### PR DESCRIPTION
There is no strong need to do so for the source code itself. However this package still uses various tools for which it gets more annoying the more PHP versions are supported.

I don't have a strong opinion as to which minimal version should be used, so I decided to align this package with PHPUnit.